### PR TITLE
Fix CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jobs:
       compiler: clang
       osx_image: xcode11.2
       env:
+        - MACOSX_DEPLOYMENT_TARGET=10.14
         - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
         - MATRIX_EVAL=""
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,6 @@ install:
 jobs:
   include:
     - os: osx
-      compiler: gcc
-      osx_image: xcode11.2    # includes gcc-9 by default
-      env:
-        # Conan is at: ${HOME}/Library/Python/2.7/bin: we need this in the path
-        - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
-        - GCC_VER="9"
-        - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
-      after_script:
-        - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
-    - os: osx
       compiler: clang
       osx_image: xcode11.2
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ jobs:
       dist: bionic
       compiler: clang
       env:
-        - MATRIX_EVAL="CC=clang && CXX=clang++"
-      addons: { apt: { packages: ['doxygen'] } }
+        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
+      addons: { apt: { packages: ['doxygen', 'clang-8'] } }
 
 
 before_script:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <array>
 
 #include <spdlog/spdlog.h>
 #include <imgui.h>


### PR DESCRIPTION
I fixed the Linux and Mac Clang builds of the project.

As far as I can tell, the Conan package for SFML is incompatible with GCC on Mac. The package specifies the compiler flag `-stdlib=libc++`, which applies to Clang but not GCC. I removed the Mac GCC build entirely. I really don't like this solution, but I'm not seeing any other option here.