### PR TITLE
Github workflow fix: use gcc-9

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -29,11 +29,19 @@ jobs:
         python3 -m pip install conan
         source ~/.profile
 
+    - name: Install gcc-9
+      run: |
+        sudo add-apt-repository ppa:ubuntu-toolchain-r-test
+        sudo apt-get install gcc-9 g++-9
+
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
       shell: bash
       working-directory: ${{runner.workspace}}/build
+      env:
+        CC: gcc-9
+        CXX: g++-9
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
@@ -46,6 +54,9 @@ jobs:
     - name: Build
       working-directory: ${{runner.workspace}}/build
       shell: bash
+      env:
+        CC: gcc-9
+        CXX: g++-9
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Install gcc-9
       run: |
-        sudo add-apt-repository ppa:ubuntu-toolchain-r-test
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get install gcc-9 g++-9
 
     - name: Configure CMake


### PR DESCRIPTION
Looks like the Github Workflows build was broken, because 'ubuntu-latest' uses gcc-7 by default. This fix updates it to gcc-9, so that c++20 is available.