### PR TITLE
Add sccache for windows

### DIFF
--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -35,4 +35,3 @@ if(ENABLE_IPO)
     message(SEND_ERROR "IPO is not supported: ${output}")
   endif()
 endif()
-

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -36,4 +36,3 @@ if(ENABLE_IPO)
   endif()
 endif()
 
-

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -10,7 +10,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
                                                "MinSizeRel" "RelWithDebInfo")
 endif()
 
-find_program(CCACHE ccache)
+find_program(CCACHE NAMES ccache sccache)
 if(CCACHE)
   message("using ccache")
   set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE})


### PR DESCRIPTION
The advantages of sccache over a ccache is that it can be installed through chocolatey on Windows

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lefticus/cpp_weekly_game_project/14)
<!-- Reviewable:end -->
