### PR TITLE
Add support for NixOS

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,23 @@
+let
+ pkgs = import <nixos> {};
+ unstable = import <nixos-unstable> {};
+
+ inherit (unstable) stdenv;
+
+ build_settings = unstable.gcc10Stdenv.mkDerivation {
+    name = "build_settings";
+
+    nativeBuildInputs = with pkgs; [
+	# Tools
+	pkgconfig unstable.cmake unstable.ninja
+	binutils gnumake libtool automake autoconf gnum4
+    ];
+
+    propagatedBuildInputs = [
+	# Libraries
+	pkgs.libGL.dev pkgs.systemd.dev
+    ];
+
+    hardeningDisable = [ "format" ];
+  };
+in build_settings


### PR DESCRIPTION
Added default.nix that builds a nix-shell capable of building this project.

[NixOS](https://nixos.org) uses sandboxing to install software so basically no libraries are available to the user when he tries compiling anything, unless the user first enters a nix-shell (basically chroot with changed parameters) first. Since this project is using conan, no external libraries are really needed, except for OpenGL and libUdev that are required by SFML, so I've added them to the default.nix and made sure gcc10 is present on the system.