### PR TITLE
Ci fix

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -29,10 +29,10 @@ jobs:
         python3 -m pip install conan
         source ~/.profile
 
-    - name: Install gcc-9
+    - name: Install gcc-10
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-        sudo apt-get install gcc-9 g++-9
+        sudo apt-get install gcc-10 g++-10
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
@@ -40,8 +40,8 @@ jobs:
       shell: bash
       working-directory: ${{runner.workspace}}/build
       env:
-        CC: gcc-9
-        CXX: g++-9
+        CC: gcc-10
+        CXX: g++-10
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
@@ -55,8 +55,8 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       env:
-        CC: gcc-9
-        CXX: g++-9
+        CC: gcc-10
+        CXX: g++-10
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ jobs:
       env:
         - MACOSX_DEPLOYMENT_TARGET=10.14
         - MATRIX_EVAL=""
-      install:  # Overrides install step below
-        # pyenv doesn't exist on this CI image, so use virtualenv to set Python version
-        - pip3 install virtualenv
-        - virtualenv -p python3 ~/venv
-        - source ~/venv/bin/activate
 
     - os: linux
       dist: bionic
@@ -45,19 +40,21 @@ jobs:
         - MATRIX_EVAL="CC=clang-${CLANG_VER} && CXX=clang++-${CLANG_VER}"
       addons: { apt: { packages: ['doxygen'] } }
 
-before_install:
+before_install: skip
   # Empty. We are using this step to add sources (as in addons/apt/sources) 
   # that Travis disallows, for example, the LLVM repo.
 
-install:
-  # Set default version of Python to 3: some Conan packages require this.
-  # This must occur before "before_script"
-  - pyenv global 3.7
+install: skip
 
 before_script:
   # Set CC and CXX
   - eval "${MATRIX_EVAL}"
-  
+
+  # Set default version of Python to 3: works the same way on Mac and Linux
+  - pip install virtualenv
+  - virtualenv -p python3 ~/venv
+  - source ~/venv/bin/activate
+
   # Fail if we are using the wrong Python
   - python --version | grep -iE 'python\s*3'
   - pip    --version | grep -iE 'python\s*3'

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,8 @@ before_script:
   - eval "${MATRIX_EVAL}"
   
   # Fail if we are using the wrong Python
-  - python --version | grep 3
-  - pip --version | grep -E 'python\s*3'
+  - python --version | grep -iE 'python\s*3'
+  - pip    --version | grep -iE 'python\s*3'
   
   # Install Conan using Python 3.
   - pip install conan cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       dist: bionic
       compiler: gcc
       env:
-        - GCC_VER="9"
+        - GCC_VER="10"
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
 
       addons:
@@ -33,8 +33,8 @@ jobs:
             - ubuntu-toolchain-r-test
           packages:
             # I couldn't get ${GCC_VER} in here successfully
-            - gcc-9
-            - g++-9
+            - gcc-10
+            - g++-10
             - doxygen
             - python3
             - python3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,12 @@ jobs:
         # Add LLVM repo and GPG key so we can install clang-10
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" | sudo tee -a /etc/apt/sources.list
+        - sudo apt-get -qq update
+        - sudo apt-get -y install clang-10
       env:
         - CLANG_VER="10"
         - MATRIX_EVAL="CC=clang-${CLANG_VER} && CXX=clang++-${CLANG_VER}"
-      addons: { apt: { packages: ['doxygen', 'clang-10'] } }
+      addons: { apt: { packages: ['doxygen'] } }
 
 before_install:
   # Empty. We are using this step to add sources (as in addons/apt/sources) 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: cpp
-python:
-  - 3.8
-  
+
+before_install:
+  # Set default version of Python to 3: some Conan packages require this.
+  - pyenv global 3.7
 install:
-  - which pip
-  - which pip3
-  - ls -al `which pip`*
-  - pip --version
-  - pip3 --version
-  - pip3 install --user conan cmake
-  
+  # Install Conan using Python 3. Fail if we have the wrong Python.
+  - python --version | grep 3
+  - pip --version | grep -E 'python\s*3'
+  - pip install conan cmake
+  # Fail if we can't run Conan.
+  - conan --version
 
 jobs:
   include:
@@ -18,8 +18,13 @@ jobs:
       osx_image: xcode11.2
       env:
         - MACOSX_DEPLOYMENT_TARGET=10.14
-        - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
         - MATRIX_EVAL=""
+      before_install:
+        # pyenv doesn't exist on this CI image, so use virtualenv to set Python version
+        - pip3 install virtualenv
+        - virtualenv -p python3 ~/venv
+        - source ~/venv/bin/activate
+
     - os: linux
       dist: bionic
       compiler: gcc
@@ -36,8 +41,6 @@ jobs:
             - gcc-10
             - g++-10
             - doxygen
-            - python3
-            - python3.8
       after_script:
         - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,5 @@
 language: cpp
 
-before_install:
-  # Set default version of Python to 3: some Conan packages require this.
-  - pyenv global 3.7
-install:
-  # Install Conan using Python 3. Fail if we have the wrong Python.
-  - python --version | grep 3
-  - pip --version | grep -E 'python\s*3'
-  - pip install conan cmake
-  # Fail if we can't run Conan.
-  - conan --version
-
 jobs:
   include:
     - os: osx
@@ -19,7 +8,7 @@ jobs:
       env:
         - MACOSX_DEPLOYMENT_TARGET=10.14
         - MATRIX_EVAL=""
-      before_install:
+      install:  # Overrides install step below
         # pyenv doesn't exist on this CI image, so use virtualenv to set Python version
         - pip3 install virtualenv
         - virtualenv -p python3 ~/venv
@@ -37,7 +26,6 @@ jobs:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            # I couldn't get ${GCC_VER} in here successfully
             - gcc-10
             - g++-10
             - doxygen
@@ -46,21 +34,37 @@ jobs:
     - os: linux
       dist: bionic
       compiler: clang
-      before_script:
-        # Add LLVM repo and GPG key before installing clang-10
+      before_install:  # Overrides before_install step below
+        # Add LLVM repo and GPG key so we can install clang-10
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" | sudo tee -a /etc/apt/sources.list
-        - sudo apt-get -qq update
-        - sudo apt-get -y install clang-10
-        - eval "${MATRIX_EVAL}"
       env:
         - CLANG_VER="10"
         - MATRIX_EVAL="CC=clang-${CLANG_VER} && CXX=clang++-${CLANG_VER}"
-      addons: { apt: { packages: ['doxygen'] } }
+      addons: { apt: { packages: ['doxygen', 'clang-10'] } }
 
+before_install:
+  # Empty. We are using this step to add sources (as in addons/apt/sources) 
+  # that Travis disallows, for example, the LLVM repo.
+
+install:
+  # Set default version of Python to 3: some Conan packages require this.
+  # This must occur before "before_script"
+  - pyenv global 3.7
 
 before_script:
+  # Set CC and CXX
   - eval "${MATRIX_EVAL}"
+  
+  # Fail if we are using the wrong Python
+  - python --version | grep 3
+  - pip --version | grep -E 'python\s*3'
+  
+  # Install Conan using Python 3.
+  - pip install conan cmake
+  
+  # Fail if we can't run Conan.
+  - conan --version
 
 script:
   - cmake -D ENABLE_COVERAGE:BOOL=TRUE .

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,17 @@ jobs:
     - os: linux
       dist: bionic
       compiler: clang
+      before_script:
+        # Add LLVM repo and GPG key before installing clang-10
+        - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" | sudo tee -a /etc/apt/sources.list
+        - sudo apt-get -qq update
+        - sudo apt-get -y install clang-10
+        - eval "${MATRIX_EVAL}"
       env:
-        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
-      addons: { apt: { packages: ['doxygen', 'clang-8'] } }
+        - CLANG_VER="10"
+        - MATRIX_EVAL="CC=clang-${CLANG_VER} && CXX=clang++-${CLANG_VER}"
+      addons: { apt: { packages: ['doxygen'] } }
 
 
 before_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,25 @@
 image:
   - Visual Studio 2019
 clone_folder: c:\projects\source
+
+environment:
+  
+  PYTHON: "C:\\Python38-x64"    # available on VS 2017 and 2019
+  
+
 build_script:
 - cmd: >-
     mkdir build
 
     cd build
 
-    pip install --user conan
+    virtualenv -p "%PYTHON%\\python.exe" venv
+
+    venv\\Scripts\\activate.bat
+
+    pip --version
+
+    pip install conan
 
     set PATH=%PATH%;C:\Users\appveyor\AppData\Roaming\Python\Scripts
 

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -60,6 +60,7 @@ function(set_project_warnings project_name)
       -Wdouble-promotion # warn if float is implicit promoted to double
       -Wformat=2 # warn on security issues around functions that format output
                  # (ie printf)
+      -Wno-unknown-attributes
   )
 
   if (WARNINGS_AS_ERRORS)

--- a/src/Input.hpp
+++ b/src/Input.hpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <variant>
 #include <chrono>
+#include <optional>
 
 
 namespace Game {


### PR DESCRIPTION
I think this fixes the CI build so far. It does a lot though, so it may need to be split up:

1. Bump GCC to 10
2. Bump Clang to 10
3. Run Conan using Python 3
4. Disable unknown-attribute warnings for Clang
5. Include &lt;optional&gt; header in Input.hpp