### PR TITLE
Fix some bugs in replay

### DIFF
--- a/src/Input.hpp
+++ b/src/Input.hpp
@@ -298,8 +298,10 @@ struct GameState
       pendingEvents.erase(pendingEvents.begin());
 
       std::visit(overloaded{
-                   [](const TimeElapsed &te) {
-                     std::this_thread::sleep_for(te.elapsed);
+                   [&](const TimeElapsed &te) {
+                     const auto timeElapsed = clock::now() - lastTick;
+                     std::this_thread::sleep_for(te.elapsed - timeElapsed);
+                     lastTick += te.elapsed;
                    },
                    [&](const Moved<Mouse> &me) {
                      sf::Mouse::setPosition({me.source.x, me.source.y}, window);

--- a/src/Input.hpp
+++ b/src/Input.hpp
@@ -131,6 +131,15 @@ struct GameState
     }
   };
 
+  struct InitialConfiguration
+  {
+    constexpr static std::string_view name{ "InitialConfiguration" };
+    constexpr static auto             elements = std::to_array<std::string_view>({ "width", "height", "scale", "imgui" });
+    long                              width;
+    long                              height;
+    long                              scale;
+    std::string                       imgui;
+  };
 
   struct Joystick
   {
@@ -206,7 +215,8 @@ struct GameState
                              Pressed<MouseButton>,
                              Released<MouseButton>,
                              CloseWindow,
-                             TimeElapsed>;
+                             TimeElapsed,
+                             InitialConfiguration>;
 
 
   static sf::Event::KeyEvent toSFMLEventInternal(const Key &key)
@@ -280,6 +290,7 @@ struct GameState
   {
     return std::visit(
       overloaded{ [&](const auto &value) -> std::optional<sf::Event> { return toSFMLEventInternal(value); },
+                  [&](const InitialConfiguration &) -> std::optional<sf::Event> { return {}; },
                   [&](const TimeElapsed &) -> std::optional<sf::Event> { return {}; },
                   [&](const std::monostate &) -> std::optional<sf::Event> { return {}; } },
       event);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,17 +103,18 @@ int main(int argc, const char **argv)
 
   std::uint64_t eventsProcessed{ 0 };
 
-  std::vector<Game::GameState::Event> events{ Game::GameState::TimeElapsed{} };
+  std::vector<Game::GameState::Event> events{ Game::GameState::TimeElapsed{}, Game::GameState::TimeElapsed{} };
 
   while (window.isOpen()) {
 
     const auto event = gs.nextEvent(window);
 
-    std::visit(Game::overloaded{ [](Game::GameState::TimeElapsed &prev, const Game::GameState::TimeElapsed &next) {
+    std::visit(Game::overloaded{ [](Game::GameState::TimeElapsed &/*prevPrev*/, Game::GameState::TimeElapsed &prev, const Game::GameState::TimeElapsed &next) {
                                   prev.elapsed += next.elapsed;
                                 },
-                                 [&](const auto & /*prev*/, const std::monostate &) {},
-                                 [&](const auto & /*prev*/, const auto &next) { events.push_back(next); } },
+                                 [&](const auto & /*prev*/, const auto & /*prev*/, const std::monostate &) {},
+                                 [&](const auto & /*prev*/, const auto & /*prev*/, const auto &next) { events.push_back(next); } },
+               *std::prev(events.end(),2),
                events.back(),
                event);
 


### PR DESCRIPTION
- Adapting replay speed to recorded scenario
- Concatenation of TimeElapsed cannot be done as proposed, need to be splitted after another event (to be able to calculate the time during which a button has been pressed, and replay it exactly) (exemple of a jump, when we start/stop pushing a button needs to be exact, in the exemple in the commit message, we may consider the button has been pressed for twice the real time (repends of the implementation for sure...))
- Gui start state needs to be recorded (windows size/scale & position of internal elements -> saved for now in imgui.ini, but needs to be reset to the state before the start of recording in order to replay it correctly) ( this commit may not be the good way to handle it, but it is more for illustration of the problem)
- Some bug still exists : mouse clic does not seems to work for windows resize (Resize event to be handled) and internal sub-windows movement/resizing does not seems to work either
