### PR TITLE
Fix CI builds

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -29,7 +29,7 @@ jobs:
         python3 -m pip install conan
         source ~/.profile
 
-    - name: Install gcc-9
+    - name: Install gcc-10
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get install gcc-10 g++-10

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -32,7 +32,10 @@ jobs:
     - name: Install gcc-9
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-        sudo apt-get install gcc-9 g++-9
+        sudo apt-get install gcc-10 g++-10
+
+    - name: Install libgl1-mesa-dev
+      run: sudo apt-get install libgl1-mesa-dev
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
@@ -40,8 +43,8 @@ jobs:
       shell: bash
       working-directory: ${{runner.workspace}}/build
       env:
-        CC: gcc-9
-        CXX: g++-9
+        CC: gcc-10
+        CXX: g++-10
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
@@ -55,8 +58,8 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       env:
-        CC: gcc-9
-        CXX: g++-9
+        CC: gcc-10
+        CXX: g++-10
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
       addons:
         apt:
           sources:
-            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${LLVM_VER} main'
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
             - clang-11

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,12 @@ jobs:
       addons:
         apt:
           sources:
+            - ubuntu-toolchain-r-test
             - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
+            - gcc-10
+            - g++-10
             - clang-11
             - clang++-11
             - doxygen

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: cpp
-python:
-  - 3.8
-  
+
 install:
-  - which pip
-  - which pip3
-  - ls -al `which pip`*
-  - pip --version
-  - pip3 --version
-  - pip3 install --user conan cmake
+  # Pip cannot install Conan without these upgrades
+  - python3 -m pip install --upgrade pip setuptools
+  # Install Conan and CMake >= 3.15
+  - python3 -m pip install conan cmake
+
+  # Fail if we can't run Conan.
+  - conan --version
   
 
 jobs:
@@ -18,7 +17,6 @@ jobs:
       osx_image: xcode11.2
       env:
         - MACOSX_DEPLOYMENT_TARGET=10.14
-        - PATH="${HOME}/Library/Python/2.7/bin:${PATH}"
         - MATRIX_EVAL=""
     - os: linux
       dist: bionic
@@ -36,8 +34,7 @@ jobs:
             - gcc-9
             - g++-9
             - doxygen
-            - python3
-            - python3.8
+            - python3-pip
       after_script:
         - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
     - os: linux
@@ -52,6 +49,7 @@ before_script:
   - eval "${MATRIX_EVAL}"
 
 script:
-  - cmake -D ENABLE_COVERAGE:BOOL=TRUE .
-  - cmake --build . -- -j2
+  - mkdir build
+  - cmake -S . -B ./build -D ENABLE_COVERAGE:BOOL=TRUE
+  - cmake --build ./build -- -j2
   - ctest -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,12 @@ jobs:
       osx_image: xcode12.2    # Let's hope this gets us a more current clang
       env:
         - MACOSX_DEPLOYMENT_TARGET=10.15
-        - MATRIX_EVAL=""
+        - LLVM_VER="11"
+        - MATRIX_EVAL="CC=clang-${LLVM_VER} && CXX=clang++-${LLVM_VER}"
+      addons:
+        homebrew:
+          packages:
+            - llvm@11
     - os: linux
       dist: bionic
       compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ jobs:
             - g++-10
             - doxygen
             - python3-pip
+            - pkg-config
+            - libgl1-mesa-dev
       after_script:
         - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
     - os: linux
@@ -52,6 +54,8 @@ jobs:
             - clang++-11
             - doxygen
             - python3-pip
+            - pkg-config
+            - libgl1-mesa-dev
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,15 @@ jobs:
   include:
     - os: osx
       compiler: clang
-      osx_image: xcode11.2
+      osx_image: xcode12.2    # Let's hope this gets us a more current clang
       env:
-        - MACOSX_DEPLOYMENT_TARGET=10.14
+        - MACOSX_DEPLOYMENT_TARGET=10.15
         - MATRIX_EVAL=""
     - os: linux
       dist: bionic
       compiler: gcc
       env:
-        - GCC_VER="9"
+        - GCC_VER="10"
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
 
       addons:
@@ -30,9 +30,8 @@ jobs:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            # I couldn't get ${GCC_VER} in here successfully
-            - gcc-9
-            - g++-9
+            - gcc-10
+            - g++-10
             - doxygen
             - python3-pip
       after_script:
@@ -41,8 +40,18 @@ jobs:
       dist: bionic
       compiler: clang
       env:
-        - MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
-      addons: { apt: { packages: ['doxygen', 'clang-8'] } }
+        - LLVM_VER="11"
+        - MATRIX_EVAL="CC=clang-${LLVM_VER} && CXX=clang++-${LLVM_VER}"
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${LLVM_VER} main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+          packages:
+            - clang-11
+            - clang++-11
+            - doxygen
+            - python3-pip
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,15 @@ jobs:
       env:
         - MACOSX_DEPLOYMENT_TARGET=10.15
         - LLVM_VER="11"
+        - CPPFLAGS="-I/usr/local/opt/llvm/include"
+        - LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
         - MATRIX_EVAL="CC=clang-${LLVM_VER} && CXX=clang++-${LLVM_VER}"
+        - PATH="/usr/local/opt/llvm/bin:$PATH"
+        - PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"
+
+        #For compilers to find libffi you may need to set:
+#        - LDFLAGS="-L/usr/local/opt/libffi/lib"
+#        - CPPFLAGS="-I/usr/local/opt/libffi/include"
       addons:
         homebrew:
           packages:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,21 @@
 image:
   - Visual Studio 2019
 clone_folder: c:\projects\source
+
+environment:
+    PYTHON: "C:\\Python38-x64\\python.exe"
+
 build_script:
 - cmd: >-
     mkdir build
 
-    cd build
+    set PATH=%PATH%;C:\Users\appveyor\AppData\Roaming\Python\Python38\Scripts
 
-    pip install --user conan
+    "%PYTHON%" -m pip install --user conan
 
-    set PATH=%PATH%;C:\Users\appveyor\AppData\Roaming\Python\Scripts
+    cmake -S c:\projects\source -B .\build -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE:STRING=Release
 
-    cmake c:\projects\source -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE:STRING=Release
-
-    cmake --build . --config "Release"
+    cmake --build .\build --config "Release"
 
 test_script:
 - cmd: ctest -C Debug

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -60,6 +60,10 @@ function(set_project_warnings project_name)
       -Wdouble-promotion # warn if float is implicit promoted to double
       -Wformat=2 # warn on security issues around functions that format output
                  # (ie printf)
+
+      # Clang doesn't recognize [[likely]] and [[unlikely]] yet.
+      # This shouldn't be here, but it fixes the linux clang build
+      -Wno-unknown-attributes
   )
 
   if (WARNINGS_AS_ERRORS)

--- a/src/Input.hpp
+++ b/src/Input.hpp
@@ -11,6 +11,7 @@
 #include <SFML/Window/Keyboard.hpp>
 #include <array>
 #include <chrono>
+#include <optional>
 #include <string>
 #include <thread>
 #include <variant>
@@ -331,7 +332,11 @@ struct GameState
     case sf::Event::JoystickButtonReleased:
       return Released<JoystickButton>{ event.joystickButton.joystickId, event.joystickButton.button };
     case sf::Event::JoystickMoved:
-      return Moved<JoystickAxis>{ event.joystickMove.joystickId, event.joystickMove.axis, event.joystickMove.position };
+      return Moved<JoystickAxis>{ 
+          event.joystickMove.joystickId, 
+          static_cast<unsigned int>(event.joystickMove.axis), 
+          event.joystickMove.position 
+      };
 
     case sf::Event::MouseButtonPressed:
       return Pressed<MouseButton>{ event.mouseButton.button, { event.mouseButton.x, event.mouseButton.y } };
@@ -397,7 +402,7 @@ template<typename EventType, typename... Param> void serialize(nlohmann::json &j
 {
   auto make_inner = [&]() {
     nlohmann::json innerObj;
-    std::size_t    index = 0;
+    [[maybe_unused]] std::size_t    index = 0;
 
     (innerObj.emplace(EventType::elements[index++], param), ...);
 


### PR DESCRIPTION
This fixes the CI builds for Windows, Linux-clang, and and Linux-gcc, on both Travis and Github Actions.

Caveat: Clang-11 does not appear to understand `[[likely]]` and `[[unlikely]]` yet. This is a temporary situation; clang-trunk recognizes them right now. I have added the flag `-Wno-unknown-attributes` to the compiler warnings to get this to build successfully; this is probably not the right solution!

I don't know how to get this to build properly on Mac. I am unable to get clang-11 to install properly, and it's hard for me to debug this since I don't have regular access to a Mac. Hopefully, someone will see this who knows how to do this. Alternately, we could just wait until September when Apple releases Apple-clang-13, which could be the equivalent of llvm-11 clang.