### PR TITLE
Fix CI builds on Windows and Linux

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -29,10 +29,13 @@ jobs:
         python3 -m pip install conan
         source ~/.profile
 
-    - name: Install gcc-9
+    - name: Install gcc-10
       run: |
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-        sudo apt-get install gcc-9 g++-9
+        sudo apt-get install gcc-10 g++-10
+
+    - name: Install libgl1-mesa-dev
+      run: sudo apt-get install libgl1-mesa-dev
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
@@ -40,8 +43,8 @@ jobs:
       shell: bash
       working-directory: ${{runner.workspace}}/build
       env:
-        CC: gcc-9
-        CXX: g++-9
+        CC: gcc-10
+        CXX: g++-10
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
@@ -55,8 +58,8 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       env:
-        CC: gcc-9
-        CXX: g++-9
+        CC: gcc-10
+        CXX: g++-10
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
 language: cpp
-python:
-  - 3.8
-  
+
 install:
-  - which pip
-  - which pip3
-  - ls -al `which pip`*
-  - pip --version
-  - pip3 --version
-  - pip3 install --user conan cmake
-  
+  # Pip cannot install Conan without these upgrades
+  - python3 -m pip install --upgrade pip setuptools
+  # Install Conan and CMake >= 3.15
+  - python3 -m pip install conan cmake
+
+  # Fail if we can't run Conan.
+  - conan --version
 
 jobs:
   include:
@@ -24,7 +22,7 @@ jobs:
       dist: bionic
       compiler: gcc
       env:
-        - GCC_VER="9"
+        - GCC_VER="10"
         - MATRIX_EVAL="CC=gcc-${GCC_VER} && CXX=g++-${GCC_VER}"
 
       addons:
@@ -33,11 +31,12 @@ jobs:
             - ubuntu-toolchain-r-test
           packages:
             # I couldn't get ${GCC_VER} in here successfully
-            - gcc-9
-            - g++-9
+            - gcc-10
+            - g++-10
             - doxygen
-            - python3
-            - python3.8
+            - python3-pip
+            - pkg-config
+            - libgl1-mesa-dev
       after_script:
         - bash <(curl -s https://codecov.io/bash) -x /usr/bin/gcov-${GCC_VER}
     - os: linux
@@ -52,6 +51,7 @@ before_script:
   - eval "${MATRIX_EVAL}"
 
 script:
-  - cmake -D ENABLE_COVERAGE:BOOL=TRUE .
-  - cmake --build . -- -j2
+  - mkdir build
+  - cmake -S . -B ./build -D ENABLE_COVERAGE:BOOL=TRUE
+  - cmake --build ./build -- -j2
   - ctest -j2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,21 @@
 image:
   - Visual Studio 2019
 clone_folder: c:\projects\source
+
+environment:
+    PYTHON: "C:\\Python38-x64\\python.exe"
+
 build_script:
 - cmd: >-
     mkdir build
 
-    cd build
+    set PATH=%PATH%;C:\Users\appveyor\AppData\Roaming\Python\Python38\Scripts
 
-    pip install --user conan
+    "%PYTHON%" -m pip install --user conan
 
-    set PATH=%PATH%;C:\Users\appveyor\AppData\Roaming\Python\Scripts
+    cmake -S c:\projects\source -B .\build -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE:STRING=Release
 
-    cmake c:\projects\source -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE:STRING=Release
-
-    cmake --build . --config "Release"
+    cmake --build .\build --config "Release"
 
 test_script:
 - cmd: ctest -C Debug

--- a/src/Input.hpp
+++ b/src/Input.hpp
@@ -11,6 +11,7 @@
 #include <SFML/Window/Keyboard.hpp>
 #include <array>
 #include <chrono>
+#include <optional>
 #include <string>
 #include <thread>
 #include <variant>
@@ -331,7 +332,9 @@ struct GameState
     case sf::Event::JoystickButtonReleased:
       return Released<JoystickButton>{ event.joystickButton.joystickId, event.joystickButton.button };
     case sf::Event::JoystickMoved:
-      return Moved<JoystickAxis>{ event.joystickMove.joystickId, event.joystickMove.axis, event.joystickMove.position };
+      return Moved<JoystickAxis>{ event.joystickMove.joystickId,
+                                  static_cast<unsigned int>(event.joystickMove.axis),
+                                  event.joystickMove.position };
 
     case sf::Event::MouseButtonPressed:
       return Pressed<MouseButton>{ event.mouseButton.button, { event.mouseButton.x, event.mouseButton.y } };
@@ -397,7 +400,7 @@ template<typename EventType, typename... Param> void serialize(nlohmann::json &j
 {
   auto make_inner = [&]() {
     nlohmann::json innerObj;
-    std::size_t    index = 0;
+    [[maybe_unused]] std::size_t index = 0;
 
     (innerObj.emplace(EventType::elements[index++], param), ...);
 


### PR DESCRIPTION
This PR fixes the CI build on Appveyor, the Linux GCC build on Travis-CI, and Github Actions build.

This PR makes no attempt to fix the clang or MacOS builds. On Linux, I cannot fix the clang build without disabling warnings or turning off "Warnings as Errors", and I don't like doing that. On Mac, I'm not sure how to get the latest clang installed properly. #23 represents my best attempt at doing that; it needs some help before it can be merged.

Although this doesn't fix all the CI builds, I think it's a lot better to have a subset of working builds than no working builds at all. This should be of some help to anyone trying to build this project on Windows or Linux.